### PR TITLE
refactoring

### DIFF
--- a/backend/controllers/AbstractController.php
+++ b/backend/controllers/AbstractController.php
@@ -19,4 +19,42 @@ abstract class AbstractController
     abstract public function updateEntity(int $id): void;
     abstract public function deleteEntity(int $id): void;
 
+
+    protected function jsonResponse(array $data, int $statusCode = 200): void
+    {
+        header('Content-Type: application/json');
+        http_response_code($statusCode);
+        echo json_encode($data);
+    }
+
+
+    protected function notFoundResponse(string $entityName): void
+    {
+        $this->jsonResponse(['message' => $entityName . ' not found'], 404);
+    }
+
+
+    protected function createdResponse(string $entityName, ?int $id = null): void
+    {
+        $response = ['message' => $entityName . ' created'];
+        if ($id !== null) {
+            $response['id'] = $id;
+        }
+        $this->jsonResponse($response, 201);
+    }
+
+
+    protected function updateResponse(string $entityName, bool $success): void
+    {
+        $this->jsonResponse(
+            ['message' => $success ? $entityName . ' updated' : 'Update failed'],
+            $success ? 200 : 400
+        );
+    }
+
+
+    protected function deleteResponse(string $entityName): void
+    {
+        $this->jsonResponse(['message' => $entityName . ' deleted'], 202);
+    }
 }

--- a/backend/controllers/PostOfficeController.php
+++ b/backend/controllers/PostOfficeController.php
@@ -16,26 +16,23 @@ class PostOfficeController extends AbstractController
     {
         $data = [];
         $offices = $this->repository->all();
-        header('Content-Type: application/json');
 
         foreach ($offices as $office) {
             $data[] = $office->jsonSerialize();
         }
 
-        echo json_encode($data);
+        $this->jsonResponse($data);
     }
 
     public function getEntityById(int $id): void
     {
         $office = $this->repository->find($id);
         if (!$office) {
-            http_response_code(404);
-            echo json_encode(['message' => 'Post office not found']);
+            $this->notFoundResponse('Post office');
             return;
         }
 
-        header('Content-Type: application/json');
-        echo json_encode($office->jsonSerialize());
+        $this->jsonResponse($office->jsonSerialize());
     }
 
     public function addEntity(): void
@@ -48,40 +45,31 @@ class PostOfficeController extends AbstractController
         $office->setPostalCode($data['postal_code']);
 
         $this->repository->save($office);
-        header('Content-Type: application/json');
-        http_response_code(201);
-        echo json_encode(['message' => 'Post office created']);
+        $this->createdResponse('Post office');
     }
 
     public function updateEntity(int $id): void
     {
         $office = $this->repository->find($id);
         if (!$office) {
-            http_response_code(404);
-            echo json_encode(['message' => 'Post office not found']);
+            $this->notFoundResponse('Post office');
             return;
         }
 
         $data = json_decode(file_get_contents('php://input'), true);
         $success = $this->repository->update($office, $data);
-        header('Content-Type: application/json');
-        http_response_code($success ? 200 : 400);
-        echo json_encode(['message' => $success ? 'Post office updated' : 'Update failed']);
+        $this->updateResponse('Post office', $success);
     }
 
     public function deleteEntity(int $id): void
     {
         $office = $this->repository->find($id);
         if (!$office) {
-            http_response_code(404);
-            echo json_encode(['message' => 'Post office not found']);
+            $this->notFoundResponse('Post office');
             return;
         }
 
         $this->repository->delete($office);
-        header('Content-Type: application/json');
-        http_response_code(202);
-        echo json_encode(['message' => 'Post office deleted']);
+        $this->deleteResponse('Post office');
     }
-
 }

--- a/backend/controllers/ShipmentController.php
+++ b/backend/controllers/ShipmentController.php
@@ -16,37 +16,35 @@ class ShipmentController extends AbstractController implements HasUserEntitiesIn
     {
         $data = [];
         $shipments = $this->repository->all();
-        header('Content-Type: application/json');
+
         foreach ($shipments as $shipment) {
             $data[] = $shipment->jsonSerialize();
         }
 
-        echo json_encode($data);
+        $this->jsonResponse($data);
     }
 
     public function getEntityByUser(int $id): void
     {
         $data = [];
         $shipments = $this->repository->findByUserId($id);
-        header('Content-Type: application/json');
+
         foreach ($shipments as $shipment) {
             $data[] = $shipment->jsonSerialize();
         }
 
-        echo json_encode($data);
+        $this->jsonResponse($data);
     }
 
     public function getEntityById(int $id): void
     {
         $shipment = $this->repository->find($id);
         if (!$shipment) {
-            http_response_code(404);
-            echo json_encode(['message' => 'Shipment not found']);
+            $this->notFoundResponse('Shipment');
             return;
         }
 
-        header('Content-Type: application/json');
-        echo json_encode($shipment->jsonSerialize());
+        $this->jsonResponse($shipment->jsonSerialize());
     }
 
     public function addEntity(): void
@@ -64,9 +62,7 @@ class ShipmentController extends AbstractController implements HasUserEntitiesIn
         $shipment->setReceiveOffice($data['receive_office']);
 
         $shipmentId = $this->repository->save($shipment);
-        header('Content-Type: application/json');
-        http_response_code(201);
-        echo json_encode(['message' => 'Shipment created', 'id' => $shipmentId]);
+        $this->createdResponse('Shipment', $shipmentId);
     }
 
     public function updateEntity(int $id): void
@@ -75,15 +71,12 @@ class ShipmentController extends AbstractController implements HasUserEntitiesIn
         $shipment = $this->repository->find($id);
 
         if (!$shipment) {
-            http_response_code(404);
-            echo json_encode(['message' => 'Shipment not found']);
+            $this->notFoundResponse('Shipment');
             return;
         }
 
         $success = $this->repository->update($shipment, $data);
-        header('Content-Type: application/json');
-        http_response_code($success ? 200 : 400);
-        echo json_encode(['message' => $success ? 'Shipment updated' : 'Update failed']);
+        $this->updateResponse('Shipment', $success);
     }
 
     public function deleteEntity(int $id): void
@@ -91,15 +84,11 @@ class ShipmentController extends AbstractController implements HasUserEntitiesIn
         $shipment = $this->repository->find($id);
 
         if (!$shipment) {
-            http_response_code(404);
-            echo json_encode(['message' => 'Shipment not found']);
+            $this->notFoundResponse('Shipment');
             return;
         }
 
         $this->repository->delete($shipment);
-        header('Content-Type: application/json');
-        http_response_code(202);
-        echo json_encode(['message' => 'Shipment deleted']);
+        $this->deleteResponse('Shipment');
     }
-
 }

--- a/backend/controllers/SupportTicketController.php
+++ b/backend/controllers/SupportTicketController.php
@@ -17,12 +17,11 @@ class SupportTicketController extends AbstractController implements HasUserEntit
         $data = [];
         $tickets = $this->repository->all();
 
-        header('Content-Type: application/json');
         foreach ($tickets as $ticket) {
             $data[] = $ticket->jsonSerialize();
         }
 
-        echo json_encode($data);
+        $this->jsonResponse($data);
     }
 
     public function getEntityById(int $id): void
@@ -30,13 +29,11 @@ class SupportTicketController extends AbstractController implements HasUserEntit
         $ticket = $this->repository->find($id);
 
         if (!$ticket) {
-            http_response_code(404);
-            echo json_encode(['message' => 'Ticket not found']);
+            $this->notFoundResponse('Ticket');
             return;
         }
 
-        header('Content-Type: application/json');
-        echo json_encode($ticket->jsonSerialize());
+        $this->jsonResponse($ticket->jsonSerialize());
     }
 
     public function getEntityByUser(int $id): void
@@ -44,12 +41,11 @@ class SupportTicketController extends AbstractController implements HasUserEntit
         $data = [];
         $tickets = $this->repository->findByUserId($id);
 
-        header('Content-Type: application/json');
         foreach ($tickets as $ticket) {
             $data[] = $ticket->jsonSerialize();
         }
 
-        echo json_encode($data);
+        $this->jsonResponse($data);
     }
 
     public function addEntity(): void
@@ -64,9 +60,7 @@ class SupportTicketController extends AbstractController implements HasUserEntit
         $ticket->setCreatedAt(time());
 
         $this->repository->save($ticket);
-        header('Content-Type: application/json');
-        http_response_code(201);
-        echo json_encode(['message' => 'Support ticket created']);
+        $this->createdResponse('Support ticket');
     }
 
     public function updateEntity(int $id): void
@@ -74,17 +68,14 @@ class SupportTicketController extends AbstractController implements HasUserEntit
         $ticket = $this->repository->find($id);
 
         if (!$ticket) {
-            http_response_code(404);
-            echo json_encode(['message' => 'Ticket not found']);
+            $this->notFoundResponse('Ticket');
             return;
         }
 
         $data = json_decode(file_get_contents('php://input'), true);
         $success = $this->repository->update($ticket, $data);
 
-        header('Content-Type: application/json');
-        http_response_code($success ? 200 : 400);
-        echo json_encode(['message' => $success ? 'Ticket updated' : 'Update failed']);
+        $this->updateResponse('Ticket', $success);
     }
 
     public function deleteEntity(int $id): void
@@ -92,15 +83,11 @@ class SupportTicketController extends AbstractController implements HasUserEntit
         $ticket = $this->repository->find($id);
 
         if (!$ticket) {
-            http_response_code(404);
-            echo json_encode(['message' => 'Ticket not found']);
+            $this->notFoundResponse('Ticket');
             return;
         }
 
         $this->repository->delete($ticket);
-        header('Content-Type: application/json');
-        http_response_code(202);
-        echo json_encode(['message' => 'Ticket deleted']);
+        $this->deleteResponse('Ticket');
     }
-
 }

--- a/backend/controllers/TrackingStatusController.php
+++ b/backend/controllers/TrackingStatusController.php
@@ -16,25 +16,23 @@ class TrackingStatusController extends AbstractController
     {
         $data = [];
         $trackingStatuses = $this->repository->all();
-        header('Content-Type: application/json');
+
         foreach ($trackingStatuses as $trackingStatus) {
             $data[] = $trackingStatus->jsonSerialize();
         }
 
-        echo json_encode($data);
+        $this->jsonResponse($data);
     }
 
     public function getEntityById(int $id): void
     {
         $trackingStatus = $this->repository->find($id);
         if (!$trackingStatus) {
-            http_response_code(404);
-            echo json_encode(['message' => 'Tracking status not found']);
+            $this->notFoundResponse('Tracking status');
             return;
         }
 
-        header('Content-Type: application/json');
-        echo json_encode($trackingStatus->jsonSerialize());
+        $this->jsonResponse($trackingStatus->jsonSerialize());
     }
 
     public function addEntity(): void
@@ -50,11 +48,8 @@ class TrackingStatusController extends AbstractController
 
         $this->repository->save($trackingStatus);
 
-        header('Content-Type: application/json');
-        http_response_code(201);
-        echo json_encode(['message' => 'Tracking status created']);
+        $this->createdResponse('Tracking status');
     }
-
 
     public function updateEntity(int $id): void
     {
@@ -62,15 +57,12 @@ class TrackingStatusController extends AbstractController
         $trackingStatus = $this->repository->find($id);
 
         if (!$trackingStatus) {
-            http_response_code(404);
-            echo json_encode(['message' => 'Tracking status not found']);
+            $this->notFoundResponse('Tracking status');
             return;
         }
 
         $success = $this->repository->update($trackingStatus, $data);
-        header('Content-Type: application/json');
-        http_response_code($success ? 200 : 400);
-        echo json_encode(['message' => $success ? 'Tracking status updated' : 'Update failed']);
+        $this->updateResponse('Tracking status', $success);
     }
 
     public function deleteEntity(int $id): void
@@ -78,15 +70,11 @@ class TrackingStatusController extends AbstractController
         $trackingStatus = $this->repository->find($id);
 
         if (!$trackingStatus) {
-            http_response_code(404);
-            echo json_encode(['message' => 'Tracking status not found']);
+            $this->notFoundResponse('Tracking status');
             return;
         }
 
         $this->repository->delete($trackingStatus);
-        header('Content-Type: application/json');
-        http_response_code(202);
-        echo json_encode(['message' => 'Tracking status deleted']);
+        $this->deleteResponse('Tracking status');
     }
-
 }


### PR DESCRIPTION
Проблема: Дублювання коду в контролерах для обробки JSON відповідей
Опис проблеми:
У всіх контролерах (PostOfficeController, ShipmentController, SupportTicketController, TrackingStatusController) присутнє значне дублювання коду для:
Встановлення заголовків Content-Type: application/json
Встановлення HTTP статус кодів
Виведення JSON відповідей
Обробки випадків "entity not found"

Я додав методи для обробки JSON відповідей в базовий клас AbstractController, аналогічно до того, як це вже зроблено в UserController. Це дозволить уніфікувати обробку відповідей та зменшити дублювання коду.