### PR TITLE
Refactoring Repository Layer to AbstractRepository Base Class

### DIFF
--- a/backend/repository/AbstractRepository.php
+++ b/backend/repository/AbstractRepository.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace repository;
+
+use PDO;
+use repository\Exception\EntityNotFoundException;
+
+abstract class AbstractRepository
+{
+    protected PDO $pdo;
+    protected string $entityClass;
+    protected string $tableName;
+
+    public function __construct(PDO $pdo, string $entityClass, string $tableName)
+    {
+        $this->pdo         = $pdo;
+        $this->entityClass = $entityClass;
+        $this->tableName   = $tableName;
+    }
+
+    public function all(): array
+    {
+        $stmt = $this->pdo->query("SELECT * FROM {$this->tableName}");
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return array_map(fn(array $row) => $this->hydrate($row), $rows);
+    }
+
+    public function find(int $id): ?object
+    {
+        $stmt = $this->pdo->prepare("SELECT * FROM {$this->tableName} WHERE id = ?");
+        $stmt->execute([$id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return $row !== false
+            ? $this->hydrate($row)
+            : null;
+    }
+
+    public function delete(object $entity): bool
+    {
+        if (!method_exists($entity, 'getId')) {
+            throw new EntityNotFoundException("Entity has no getId method");
+        }
+
+        $stmt = $this->pdo->prepare("DELETE FROM {$this->tableName} WHERE id = ?");
+        return $stmt->execute([$entity->getId()]);
+    }
+
+    abstract protected function hydrate(array $row): object;
+}

--- a/backend/repository/SupportTicketRepository.php
+++ b/backend/repository/SupportTicketRepository.php
@@ -2,54 +2,33 @@
 
 namespace repository;
 
-use config\Database;
-use models\SupportTicket;
 use PDO;
+use models\SupportTicket;
 
-class SupportTicketRepository implements RepositoryInterface
+class SupportTicketRepository extends AbstractRepository implements RepositoryInterface
 {
-    public function all(): array
+    public function __construct(PDO $pdo)
     {
-        $pdo = Database::getInstance();
-        $stmt = $pdo->query("SELECT * FROM support_tickets");
-
-        $tickets = [];
-        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            $tickets[] = $this->hydrate($row);
-        }
-
-        return $tickets;
-    }
-
-    public function find(int $id): ?SupportTicket
-    {
-        $pdo = Database::getInstance();
-        $stmt = $pdo->prepare("SELECT * FROM support_tickets WHERE id = ?");
-        $stmt->execute([$id]);
-        $row = $stmt->fetch(PDO::FETCH_ASSOC);
-
-        return $row ? $this->hydrate($row) : null;
+        parent::__construct($pdo, SupportTicket::class, 'support_tickets');
     }
 
     public function findByUserId(int $userId): array
     {
-        $pdo = Database::getInstance();
-        $stmt = $pdo->prepare("SELECT * FROM support_tickets WHERE user_id = ?");
+        $stmt = $this->pdo->prepare("
+            SELECT * FROM {$this->tableName}
+            WHERE user_id = ?
+        ");
         $stmt->execute([$userId]);
 
-        $tickets = [];
-        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            $tickets[] = $this->hydrate($row);
-        }
-
-        return $tickets;
+        $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+        return array_map(fn($r) => $this->hydrate($r), $rows);
     }
 
     public function save(object $entity): int
     {
-        $pdo = Database::getInstance();
-        $stmt = $pdo->prepare("
-            INSERT INTO support_tickets (user_id, subject, message, response, status, created_at)
+        $stmt = $this->pdo->prepare("
+            INSERT INTO {$this->tableName}
+              (user_id, subject, message, response, status, created_at)
             VALUES (?, ?, ?, ?, ?, ?)
         ");
 
@@ -62,48 +41,36 @@ class SupportTicketRepository implements RepositoryInterface
             $entity->getCreatedAt(),
         ]);
 
-        return (int) $pdo->lastInsertId();
+        return (int)$this->pdo->lastInsertId();
     }
 
     public function update(object $entity, array $fields): bool
     {
-        $pdo = Database::getInstance();
-        $setClauses = [];
-        $values = [];
-
-        foreach ($fields as $key => $value) {
-            $setClauses[] = "$key = ?";
-            $values[] = $value;
+        if (empty($fields)) {
+            return false;
         }
 
-        if (empty($setClauses)) return false;
+        $setClauses = array_map(fn($k) => "$k = ?", array_keys($fields));
+        $values     = array_values($fields);
+        $values[]   = $entity->getId();
 
-        $values[] = $entity->getId();
-        $sql = "UPDATE support_tickets SET " . implode(', ', $setClauses) . " WHERE id = ?";
-        $stmt = $pdo->prepare($sql);
+        $sql  = "UPDATE {$this->tableName} SET " . implode(', ', $setClauses) . " WHERE id = ?";
+        $stmt = $this->pdo->prepare($sql);
 
         return $stmt->execute($values);
     }
 
-    public function delete(object $entity): bool
+    protected function hydrate(array $row): object
     {
-        $pdo = Database::getInstance();
-        $stmt = $pdo->prepare("DELETE FROM support_tickets WHERE id = ?");
-        return $stmt->execute([$entity->getId()]);
+        $t = new SupportTicket();
+        $t->setId((int)$row['id']);
+        $t->setUserId((int)$row['user_id']);
+        $t->setSubject($row['subject']);
+        $t->setMessage($row['message']);
+        $t->setResponse($row['response']);
+        $t->setStatus($row['status']);
+        $t->setCreatedAt((int)$row['created_at']);
+
+        return $t;
     }
-
-    private function hydrate(array $row): SupportTicket
-    {
-        $ticket = new SupportTicket();
-        $ticket->setId($row['id']);
-        $ticket->setUserId($row['user_id']);
-        $ticket->setSubject($row['subject']);
-        $ticket->setMessage($row['message']);
-        $ticket->setResponse($row['response']);
-        $ticket->setStatus($row['status']);
-        $ticket->setCreatedAt($row['created_at']);
-
-        return $ticket;
-    }
-
 }

--- a/backend/repository/UserRepository.php
+++ b/backend/repository/UserRepository.php
@@ -2,108 +2,91 @@
 
 namespace repository;
 
-use config\Database;
-use models\User;
 use PDO;
+use models\User;
 
-class UserRepository implements RepositoryInterface
+class UserRepository extends AbstractRepository implements RepositoryInterface
 {
-    public function all(): array
+    public function __construct(PDO $pdo)
     {
-        $pdo = Database::getInstance();
-        $stmt = $pdo->query("SELECT * FROM users");
-
-        $users = [];
-        while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-            $users[] = $this->hydrateUser($row);
-        }
-        return $users;
-    }
-
-    public function find(int $id): ?User
-    {
-        $pdo = Database::getInstance();
-        $stmt = $pdo->prepare("SELECT * FROM users WHERE id = ?");
-        $stmt->execute([$id]);
-        $row = $stmt->fetch(PDO::FETCH_ASSOC);
-        return $row ? $this->hydrateUser($row) : null;
+        parent::__construct($pdo, User::class, 'users');
     }
 
     public function findByEmail(string $email): ?User
     {
-        $pdo = Database::getInstance();
-        $stmt = $pdo->prepare("SELECT * FROM users WHERE email = :email");
+        $stmt = $this->pdo
+            ->prepare("SELECT * FROM {$this->tableName} WHERE email = :email");
         $stmt->execute(['email' => $email]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
-        return $row ? $this->hydrateUser($row) : null;
+
+        return $row ? $this->hydrate($row) : null;
     }
 
     public function save(object $entity): int
     {
-        $pdo = Database::getInstance();
-        $stmt = $pdo->prepare("
-            INSERT INTO users (name, surname, email, password, phone_number, role)
-            VALUES (?, ? ,?, ?, ?, ?)
+        $stmt = $this->pdo->prepare("
+            INSERT INTO {$this->tableName}
+              (name, surname, email, password, phone_number, role)
+            VALUES (?, ?, ?, ?, ?, ?)
         ");
-        $hashedPassword = password_hash($entity->getPassword(), PASSWORD_DEFAULT);
+
+        $hashed = password_hash($entity->getPassword(), PASSWORD_DEFAULT);
         $stmt->execute([
             $entity->getName(),
             $entity->getSurname(),
             $entity->getEmail(),
-            $hashedPassword,
+            $hashed,
             $entity->getPhoneNumber(),
             $entity->getRole() ?? User::ROLE_USER,
         ]);
 
-        return (int) $pdo->lastInsertId();
+        return (int)$this->pdo->lastInsertId();
     }
 
     public function update(object $entity, array $fields): bool
     {
-        $pdo = Database::getInstance();
+        if (empty($fields)) {
+            return false;
+        }
 
         $setClauses = [];
-        $values = [];
+        $values     = [];
 
         foreach ($fields as $key => $value) {
             if ($key === 'password') {
+                // якщо пароль змінився — хешуємо
                 if (!password_verify($value, $entity->getPassword())) {
                     $value = password_hash($value, PASSWORD_DEFAULT);
                 } else {
-                    continue;
+                    continue; // пропускаємо, якщо без змін
                 }
             }
             $setClauses[] = "$key = ?";
-            $values[] = $value;
+            $values[]     = $value;
         }
 
-        if (empty($setClauses)) return false;
+        if (empty($setClauses)) {
+            return false;
+        }
 
         $values[] = $entity->getId();
+        $sql      = "UPDATE {$this->tableName} SET " . implode(', ', $setClauses) . " WHERE id = ?";
+        $stmt     = $this->pdo->prepare($sql);
 
-        $sql = "UPDATE users SET " . implode(', ', $setClauses) . " WHERE id = ?";
-        $stmt = $pdo->prepare($sql);
         return $stmt->execute($values);
     }
 
-    public function delete(object $entity): bool
+    protected function hydrate(array $row): object
     {
-        $pdo = Database::getInstance();
-        $stmt = $pdo->prepare("DELETE FROM users WHERE id = ?");
-        return $stmt->execute([$entity->getId()]);
-    }
+        $u = new User();
+        $u->setId((int)$row['id']);
+        $u->setName($row['name']);
+        $u->setSurname($row['surname']);
+        $u->setEmail($row['email']);
+        $u->setPassword($row['password']);
+        $u->setPhoneNumber($row['phone_number']);
+        $u->setRole($row['role']);
 
-    private function hydrateUser(array $row): User
-    {
-        $user = new User();
-        $user->setId($row['id']);
-        $user->setName($row['name']);
-        $user->setSurname($row['surname']);
-        $user->setEmail($row['email']);
-        $user->setPassword($row['password']);
-        $user->setPhoneNumber($row['phone_number']);
-        $user->setRole($row['role']);
-        return $user;
+        return $u;
     }
-
 }


### PR DESCRIPTION
## Issue:
All repository classes ([PostOffice](./backend/repository/PostOfficeRepository.php), [Shipment](./backend/repository/ShipmentRepository.php), [SupportTicket](./backend/repository/SupportTicketRepository.php), [TrackingStatus](./backend/repository/TrackingStatusRepository.php), [User](./backend/repository/UserRepository.php)) contain duplicated CRUD logic:
- Static calls to Database::getInstance()

- Nearly identical implementations of all(), find($id), delete($entity)

- Boilerplate loops plus per-entity hydrateXxx() methods

This violates DRY and makes unit-testing (mocking PDO) practically impossible.

## Solution:
Introduce an [AbstractRepository](./backend/repository/AbstractRepository.php) generic base class that:

- Receives a PDO instance, table name and entity class via its constructor.

- Implements common methods all(), find(), delete() once and for all.

- Declares an abstract hydrate(array $row): object for subclasses to map rows to entities.

Each concrete repository then:

- Extends [AbstractRepository](./backend/repository/AbstractRepository.php) and implements only its own save(), update() and any custom findBy…() methods.

- Injects PDO in its constructor (no more static Database::getInstance()).

## Changes:

- Created repository/AbstractRepository.php with generic CRUD logic.

  - Updated each repository class to inherit from AbstractRepository:

  - Replaced static DB calls with injected $this->pdo.

  - Removed duplicated all(), find(), delete() methods.

  - Kept only entity-specific save(), update(), (and findByUserId() / findByEmail() where needed).

  - Unified per-entity mapping via a single hydrate() override.

## Result:

DRY code: one place for common CRUD.

Testable repositories: PDO can be mocked or swapped for in-memory SQLite.

Maintainable and extensible: adding a new repository now requires only ~15 lines.